### PR TITLE
builder: add i18n architecture with Chinese/English support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ai-polymarket-frontend</title>
+    <title>AI Predict</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "ai-polymarket-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "i18next": "^25.8.7",
+        "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-i18next": "^16.5.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -261,6 +264,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2477,6 +2489,55 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.7.tgz",
+      "integrity": "sha512-ttxxc5+67S/0hhoeVdEgc1lRklZhdfcUSEPp1//uUG2NB88X3667gRsDar+ZWQFdysnOsnb32bcoMsa4mtzhkQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2901,6 +2962,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.4.tgz",
+      "integrity": "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3095,7 +3183,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3177,6 +3265,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -3250,6 +3347,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "i18next": "^25.8.7",
+    "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-i18next": "^16.5.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/App.css
+++ b/src/App.css
@@ -12,10 +12,12 @@ body { margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, sans-s
 
 .app { max-width: 1120px; margin: 0 auto; padding: 20px; }
 .topbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; background: rgba(14,20,33,.86); border: 1px solid var(--line); border-radius: 12px; backdrop-filter: blur(8px); }
+.topbar-right { display: flex; align-items: center; gap: 12px; }
 .brand { font-weight: 800; letter-spacing: .2px; }
 nav { display: flex; gap: 18px; color: var(--muted); }
 nav a { cursor: pointer; }
 .connect { background: var(--accent); border: 0; color: white; padding: 10px 14px; border-radius: 10px; font-weight: 600; }
+.language-switcher { background: var(--panel); color: var(--text); border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; font-size: 14px; cursor: pointer; }
 
 .hero { margin-top: 20px; background: linear-gradient(130deg, rgba(15,123,255,.2), rgba(15,123,255,.03)); border: 1px solid var(--line); border-radius: 14px; padding: 22px; }
 .hero h1 { margin: 0 0 8px; font-size: 30px; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,46 +1,52 @@
-import { useEffect, useMemo, useState } from 'react'
-import './App.css'
-import { marketApi } from './services/api'
-import type { Market } from './types/market'
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import './App.css';
+import { marketApi } from './services/api';
+import type { Market } from './types/market';
+import { LanguageSwitcher } from './components/LanguageSwitcher';
 
-const categories = ['All', 'Crypto', 'AI', 'Politics', 'Sports']
+const categoryKeys = ['all', 'crypto', 'ai', 'politics', 'sports'] as const;
 
 function App() {
-  const [markets, setMarkets] = useState<Market[]>([])
-  const [category, setCategory] = useState('All')
-  const [query, setQuery] = useState('')
+  const { t } = useTranslation();
+  const [markets, setMarkets] = useState<Market[]>([]);
+  const [category, setCategory] = useState('All');
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
-    marketApi.listMarkets({ category, query }).then(setMarkets)
-  }, [category, query])
+    marketApi.listMarkets({ category, query }).then(setMarkets);
+  }, [category, query]);
 
   const totalVolume = useMemo(
     () => markets.reduce((sum, m) => sum + m.volumeUsd, 0),
     [markets],
-  )
+  );
 
   return (
     <div className="app">
       <header className="topbar">
         <div className="brand">AI Predict</div>
         <nav>
-          <a>Markets</a>
-          <a>Portfolio</a>
-          <a>Leaderboard</a>
+          <a>{t('nav.markets')}</a>
+          <a>{t('nav.portfolio')}</a>
+          <a>{t('nav.leaderboard')}</a>
         </nav>
-        <button className="connect">Connect Wallet</button>
+        <div className="topbar-right">
+          <LanguageSwitcher />
+          <button className="connect">{t('nav.connectWallet')}</button>
+        </div>
       </header>
 
       <section className="hero">
-        <h1>Prediction Markets, Real-Time Sentiment</h1>
-        <p>Polymarket-inspired UI with backend-ready architecture.</p>
+        <h1>{t('hero.title')}</h1>
+        <p>{t('hero.subtitle')}</p>
         <div className="stats">
           <div>
-            <span>Total Markets</span>
+            <span>{t('stats.totalMarkets')}</span>
             <strong>{markets.length}</strong>
           </div>
           <div>
-            <span>Total Volume</span>
+            <span>{t('stats.totalVolume')}</span>
             <strong>${totalVolume.toLocaleString()}</strong>
           </div>
         </div>
@@ -50,11 +56,13 @@ function App() {
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search markets..."
+          placeholder={t('filters.search')}
         />
         <select value={category} onChange={(e) => setCategory(e.target.value)}>
-          {categories.map((c) => (
-            <option key={c}>{c}</option>
+          {categoryKeys.map((c) => (
+            <option key={c} value={c === 'all' ? 'All' : c.charAt(0).toUpperCase() + c.slice(1)}>
+              {t(`categories.${c}`)}
+            </option>
           ))}
         </select>
       </section>
@@ -64,9 +72,9 @@ function App() {
           <article key={m.id} className="card">
             <div className="chip">{m.category}</div>
             <h3>{m.title}</h3>
-            <p>Ends: {m.endDate}</p>
+            <p>{t('market.ends')}: {m.endDate}</p>
             <p>
-              Vol ${m.volumeUsd.toLocaleString()} · Liq ${m.liquidityUsd.toLocaleString()}
+              {t('market.volume')} ${m.volumeUsd.toLocaleString()} · {t('market.liquidity')} ${m.liquidityUsd.toLocaleString()}
             </p>
             <div className="outcomes">
               {m.outcomes.map((o) => (
@@ -79,7 +87,7 @@ function App() {
         ))}
       </main>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n';
+
+export function LanguageSwitcher() {
+  const { i18n, t } = useTranslation();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value as SupportedLanguage;
+    i18n.changeLanguage(lang);
+    window.location.search = `?locale=${lang}`;
+  };
+
+  return (
+    <select
+      value={i18n.language}
+      onChange={handleChange}
+      className="language-switcher"
+      aria-label={t('language.switch')}
+    >
+      {SUPPORTED_LANGUAGES.map((lang) => (
+        <option key={lang} value={lang}>
+          {t(`language.${lang}`)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,38 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import en from './locales/en.json';
+import zh from './locales/zh.json';
+
+export const SUPPORTED_LANGUAGES = ['en', 'zh'] as const;
+export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
+
+const resources = {
+  en: { translation: en },
+  zh: { translation: zh },
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'en',
+    supportedLngs: SUPPORTED_LANGUAGES,
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['querystring', 'localStorage', 'navigator'],
+      caches: ['localStorage'],
+      lookupQuerystring: 'locale',
+      lookupLocalStorage: 'language',
+    },
+  });
+
+i18n.on('languageChanged', (lng) => {
+  document.documentElement.lang = lng;
+});
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,37 @@
+{
+  "nav": {
+    "markets": "Markets",
+    "portfolio": "Portfolio",
+    "leaderboard": "Leaderboard",
+    "connectWallet": "Connect Wallet"
+  },
+  "hero": {
+    "title": "Prediction Markets, Real-Time Sentiment",
+    "subtitle": "Polymarket-inspired UI with backend-ready architecture."
+  },
+  "stats": {
+    "totalMarkets": "Total Markets",
+    "totalVolume": "Total Volume"
+  },
+  "filters": {
+    "search": "Search markets...",
+    "category": "Category"
+  },
+  "market": {
+    "ends": "Ends",
+    "volume": "Vol",
+    "liquidity": "Liq"
+  },
+  "categories": {
+    "all": "All",
+    "crypto": "Crypto",
+    "ai": "AI",
+    "politics": "Politics",
+    "sports": "Sports"
+  },
+  "language": {
+    "switch": "Language",
+    "en": "English",
+    "zh": "中文"
+  }
+}

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1,0 +1,37 @@
+{
+  "nav": {
+    "markets": "市场",
+    "portfolio": "投资组合",
+    "leaderboard": "排行榜",
+    "connectWallet": "连接钱包"
+  },
+  "hero": {
+    "title": "预测市场，实时情绪",
+    "subtitle": "受 Polymarket 启发的 UI，具有后端就绪架构。"
+  },
+  "stats": {
+    "totalMarkets": "市场总数",
+    "totalVolume": "总成交量"
+  },
+  "filters": {
+    "search": "搜索市场...",
+    "category": "分类"
+  },
+  "market": {
+    "ends": "结束于",
+    "volume": "成交量",
+    "liquidity": "流动性"
+  },
+  "categories": {
+    "all": "全部",
+    "crypto": "加密货币",
+    "ai": "人工智能",
+    "politics": "政治",
+    "sports": "体育"
+  },
+  "language": {
+    "switch": "语言",
+    "en": "English",
+    "zh": "中文"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './i18n';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,6 +15,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- Implemented i18n architecture using react-i18next with Chinese/English support
- Added language switcher in top navigation bar
- Replaced all hardcoded strings with translation keys
- Implemented locale persistence via localStorage and URL query parameter precedence
- Added browser language detection with English fallback
- Architecture is extensible for future locales (add to SUPPORTED_LANGUAGES in src/i18n/index.ts)

## Changes
- Added i18n configuration with language detection (URL > localStorage > browser > fallback)
- Created translation files: src/i18n/locales/en.json, src/i18n/locales/zh.json
- Created LanguageSwitcher component in src/components/LanguageSwitcher.tsx
- Updated App.tsx with all translated strings
- Added CSS styles for language switcher

## Usage
- Switch language via dropdown in top nav
- Set locale via URL: `?locale=zh` or `?locale=en`
- Language preference persists in localStorage

Closes #1