### PR TITLE
feat: QA trigger workflow via Telegram (closes #14)

### DIFF
--- a/.github/workflows/qa-trigger.yml
+++ b/.github/workflows/qa-trigger.yml
@@ -1,0 +1,45 @@
+name: QA Trigger
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  qa-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR info
+        id: pr-info
+        run: |
+          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "url=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
+
+      - name: Set Telegram credentials
+        id: telegram-creds
+        run: |
+          if [ -n "${{ secrets.TELEGRAMBOTTOKEN }}" ]; then
+            echo "bot_token=${{ secrets.TELEGRAMBOTTOKEN }}" >> $GITHUB_OUTPUT
+            echo "chat_id=${{ secrets.TELEGRAMCHATID }}" >> $GITHUB_OUTPUT
+          else
+            echo "bot_token=${{ secrets.TELEGRAM_BOT_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Telegram message
+        if: steps.telegram-creds.outputs.bot_token != ''
+        run: |
+          MESSAGE="QA: please review PR #${{ steps.pr-info.outputs.number }} ${{ steps.pr-info.outputs.url }}"
+          curl -s -X POST "https://api.telegram.org/bot${{ steps.telegram-creds.outputs.bot_token }}/sendMessage" \
+            -d "chat_id=${{ steps.telegram-creds.outputs.chat_id }}" \
+            -d "text=${MESSAGE}"
+
+      - name: Request review from orion-qa
+        run: |
+          curl -s -X POST "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.pr-info.outputs.number }}/requested_reviewers" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -d '{"reviewers":["orion-qa"]}'

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ Notes:
 - No tokens are stored in the repo; scripts rely on your machine's `gh auth` profiles.
 - `gh_as.sh` runs `gh auth setup-git` to keep git HTTPS auth aligned with the active role.
 
+## QA Review Automation
+
+The repository includes a GitHub Actions workflow (`.github/workflows/qa-trigger.yml`) that automatically:
+- Sends a Telegram message to the project group when a PR is opened, reopened, or marked ready for review
+- Requests a review from the `orion-qa` team
+
+### Setup
+
+To enable Telegram notifications:
+
+1. Create a Telegram bot via @BotFather and get the bot token
+2. Add the bot to your Telegram group and get the group chat ID
+3. Add the following secrets to your GitHub repository:
+   - `TELEGRAMBOTTOKEN` (or `TELEGRAM_BOT_TOKEN` as alternative)
+   - `TELEGRAMCHATID` (or `TELEGRAM_CHAT_ID` as alternative)
+
+Go to: Repository Settings → Secrets and variables → Actions → New repository secret
+
 Polymarket-inspired frontend (design language + color style), implemented with React + TypeScript + Vite, and structured for future backend integration.
 
 参考 Polymarket 的前端风格与配色，使用 React + TypeScript + Vite 实现，并预留后端接入接口。


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to trigger QA review on PR events
- Send Telegram notification to project group
- Request orion-qa as reviewer via GitHub API
- Support both TELEGRAMBOTTOKEN/TELEGRAMCHATID and TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID secrets
- Update README with setup instructions