### PR TITLE
feat: change hero title to AI Predict Admin v2 (closes #29)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -6,7 +6,7 @@
     "connectWallet": "Connect Wallet"
   },
   "hero": {
-    "title": "Prediction Markets, Real-Time Sentiment",
+    "title": "AI Predict Admin",
     "subtitle": "Polymarket-inspired UI with backend-ready architecture."
   },
   "stats": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -6,7 +6,7 @@
     "connectWallet": "连接钱包"
   },
   "hero": {
-    "title": "预测市场，实时情绪",
+    "title": "AI Predict Admin",
     "subtitle": "受 Polymarket 启发的 UI，具有后端就绪架构。"
   },
   "stats": {


### PR DESCRIPTION
## Summary
- Change hero.title to AI Predict Admin in en.json and zh.json