### PR TITLE
feat: Add health-check banner on homepage (closes #37)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,8 @@ body { margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, sans-s
 .topbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; background: rgba(14,20,33,.86); border: 1px solid var(--line); border-radius: 12px; backdrop-filter: blur(8px); }
 .topbar-right { display: flex; align-items: center; gap: 12px; }
 .brand { font-weight: 800; letter-spacing: .2px; }
+.backend-status { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); font-size: 12px; padding: 4px 10px; border-radius: 6px; background: #22c55e22; color: #4ade80; border: 1px solid #22c55e44; }
+.backend-status.unreachable { background: #ef444422; color: #f87171; border-color: #ef444444; }
 nav { display: flex; gap: 18px; color: var(--muted); }
 nav a { cursor: pointer; }
 .connect { background: var(--accent); border: 0; color: white; padding: 10px 14px; border-radius: 10px; font-weight: 600; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,20 @@ function MarketsPage() {
   const [markets, setMarkets] = useState<Market[]>([])
   const [category, setCategory] = useState('All')
   const [query, setQuery] = useState('')
+  const [backendStatus, setBackendStatus] = useState<'ok' | 'unreachable' | null>(null);
+
+  useEffect(() => {
+    const apiUrl = import.meta.env.VITE_API_BASE_URL;
+    if (apiUrl) {
+      fetch(`${apiUrl}/health`)
+        .then((res) => {
+          setBackendStatus(res.ok ? 'ok' : 'unreachable');
+        })
+        .catch(() => {
+          setBackendStatus('unreachable');
+        });
+    }
+  }, []);
 
   useEffect(() => {
     marketApi.listMarkets({ category, query }).then(setMarkets)
@@ -31,6 +45,11 @@ function MarketsPage() {
   return (
     <div className="app">
       <header className="topbar">
+        {backendStatus && (
+          <div className={`backend-status ${backendStatus === 'unreachable' ? 'unreachable' : ''}`}>
+            Backend: {backendStatus === 'ok' ? 'OK' : 'unreachable'}
+          </div>
+        )}
         <div className="brand">AI Predict</div>
         <nav>
           <a>{t('nav.markets')}</a>


### PR DESCRIPTION
## Summary
- Add deterministic health-check request on homepage load using VITE_API_BASE_URL
- Display status line 'Backend: OK' or 'Backend: unreachable' in topbar
- Trigger network request to ${VITE_API_BASE_URL}/health when env is set

Closes #37