### PR TITLE
builder: feat(issue-10): admin auth seed with email login

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ npm run dev
 npm run build
 ```
 
+## Admin Authentication
+
+### Demo Credentials
+- Orion: shaoshixiong@gmail.com
+- Mark: mark@locatechs.com
+
+### Access
+1. Navigate to `/admin/login`
+2. Enter any demo email or click a demo account button
+3. Session persists via localStorage
+
 ## Next Milestones
 1. Route system + detail page
 2. Wallet connect flow

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,8 +1,33 @@
 import express from 'express';
 import cors from 'cors';
+import crypto from 'crypto';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+const ADMIN_USERS = [
+  {
+    id: '1',
+    email: 'shaoshixiong@gmail.com',
+    name: 'Orion',
+    role: 'admin',
+    walletAddress: null,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: '2',
+    email: 'mark@locatechs.com',
+    name: 'Mark',
+    role: 'admin',
+    walletAddress: null,
+    createdAt: new Date().toISOString(),
+  },
+];
+
+const generateToken = (user) => {
+  const payload = { id: user.id, email: user.email, role: user.role };
+  return Buffer.from(JSON.stringify(payload)).toString('base64');
+};
 
 const corsOptions = {
   origin: [
@@ -30,7 +55,29 @@ app.get('/', (req, res) => {
   res.json({
     service: 'b1-backend',
     version: '1.0.0',
-    endpoints: ['/health'],
+    endpoints: ['/health', '/auth/login'],
+  });
+});
+
+app.post('/auth/login', (req, res) => {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  const user = ADMIN_USERS.find((u) => u.email === email);
+
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const token = generateToken(user);
+  const { password, ...userWithoutPassword } = user;
+
+  res.json({
+    token,
+    user: userWithoutPassword,
   });
 });
 

--- a/src/App.css
+++ b/src/App.css
@@ -43,3 +43,39 @@ nav a { cursor: pointer; }
   nav { display: none; }
   .filters { grid-template-columns: 1fr; }
 }
+
+.user-indicator { display: flex; align-items: center; gap: 8px; }
+.user-email { font-size: 13px; color: var(--muted); }
+.logout-btn { background: transparent; border: 1px solid var(--line); color: var(--muted); padding: 6px 10px; border-radius: 8px; font-size: 12px; cursor: pointer; }
+.logout-btn:hover { background: var(--line); }
+
+.login-page { min-height: 100vh; display: flex; align-items: center; justify-content: center; background: radial-gradient(1200px 500px at 20% -10%, #15325e, var(--bg)); }
+.login-card { background: var(--panel); border: 1px solid var(--line); border-radius: 16px; padding: 32px; width: 100%; max-width: 380px; }
+.login-card h1 { margin: 0 0 8px; font-size: 24px; }
+.login-subtitle { color: var(--muted); margin: 0 0 24px; }
+.form-group { margin-bottom: 16px; }
+.form-group label { display: block; margin-bottom: 6px; font-size: 14px; }
+.form-group input { width: 100%; background: var(--bg); color: var(--text); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; }
+.error-message { color: #f87171; font-size: 14px; margin-bottom: 16px; }
+.login-btn { width: 100%; background: var(--accent); border: 0; color: white; padding: 12px; border-radius: 10px; font-weight: 600; cursor: pointer; }
+.login-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.demo-section { margin-top: 24px; padding-top: 24px; border-top: 1px solid var(--line); }
+.demo-section p { color: var(--muted); font-size: 14px; margin: 0 0 12px; }
+.demo-buttons { display: flex; gap: 8px; }
+.demo-btn { flex: 1; background: var(--bg); border: 1px solid var(--line); color: var(--text); padding: 8px; border-radius: 8px; cursor: pointer; }
+.demo-btn:hover { background: var(--line); }
+
+.admin-layout { display: flex; min-height: 100vh; }
+.sidebar { width: 220px; background: var(--panel); border-right: 1px solid var(--line); padding: 20px; display: flex; flex-direction: column; }
+.sidebar .brand { font-weight: 800; letter-spacing: .2px; margin-bottom: 24px; }
+.sidebar nav { display: flex; flex-direction: column; gap: 8px; }
+.nav-link { padding: 10px 12px; border-radius: 8px; color: var(--muted); text-decoration: none; }
+.nav-link:hover { background: var(--bg); }
+.nav-link.active { background: var(--accent); color: white; }
+.sidebar-footer { margin-top: auto; padding-top: 20px; }
+.main-content { flex: 1; display: flex; flex-direction: column; }
+.main-content .topbar { display: flex; justify-content: space-between; align-items: center; border-radius: 0; border-left: 0; border-right: 0; }
+.header-right { display: flex; align-items: center; gap: 16px; }
+.back-link { color: var(--muted); text-decoration: none; font-size: 14px; }
+.back-link:hover { color: var(--text); }
+.main-content main { padding: 24px; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,10 @@ import { EventsPage } from './pages/admin/Events'
 import { OddsPage } from './pages/admin/Odds'
 import { SettlementPage } from './pages/admin/Settlement'
 import { TokenFiatPage } from './pages/admin/TokenFiat'
+import { AdminLoginPage } from './pages/admin/Login'
+import { AuthProvider } from './contexts/AuthContext'
+import { ProtectedRoute } from './components/ProtectedRoute'
+import { useAuth } from './contexts/AuthContext'
 
 const categoryKeys = ['all', 'crypto', 'ai', 'politics', 'sports'] as const
 
@@ -19,6 +23,7 @@ function MarketsPage() {
   const [category, setCategory] = useState('All')
   const [query, setQuery] = useState('')
   const [backendStatus, setBackendStatus] = useState<'ok' | 'unreachable' | null>(null);
+  const { user, isAuthenticated, logout } = useAuth()
 
   useEffect(() => {
     const apiUrl = import.meta.env.VITE_API_BASE_URL;
@@ -58,7 +63,14 @@ function MarketsPage() {
         </nav>
         <div className="topbar-right">
           <LanguageSwitcher />
-          <button className="connect">{t('nav.connectWallet')}</button>
+          {isAuthenticated ? (
+            <div className="user-indicator">
+              <span className="user-email">{user?.email}</span>
+              <button className="logout-btn" onClick={logout}>Logout</button>
+            </div>
+          ) : (
+            <button className="connect">{t('nav.connectWallet')}</button>
+          )}
         </div>
       </header>
 
@@ -117,15 +129,18 @@ function MarketsPage() {
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<MarketsPage />} />
-      <Route path="/admin" element={<AdminLayout />}>
-        <Route path="events" element={<EventsPage />} />
-        <Route path="odds" element={<OddsPage />} />
-        <Route path="settlement" element={<SettlementPage />} />
-        <Route path="tokens" element={<TokenFiatPage />} />
-      </Route>
-    </Routes>
+    <AuthProvider>
+      <Routes>
+        <Route path="/" element={<MarketsPage />} />
+        <Route path="/admin/login" element={<AdminLoginPage />} />
+        <Route path="/admin" element={<ProtectedRoute><AdminLayout /></ProtectedRoute>}>
+          <Route path="events" element={<EventsPage />} />
+          <Route path="odds" element={<OddsPage />} />
+          <Route path="settlement" element={<SettlementPage />} />
+          <Route path="tokens" element={<TokenFiatPage />} />
+        </Route>
+      </Routes>
+    </AuthProvider>
   )
 }
 

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,18 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import type { ReactNode } from 'react';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/admin/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  role: 'admin';
+  walletAddress: string | null;
+}
+
+export interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (email: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('b1_auth');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        setToken(parsed.token);
+        setUser(parsed.user);
+      } catch {
+        localStorage.removeItem('b1_auth');
+      }
+    }
+  }, []);
+
+  const login = async (email: string) => {
+    const res = await fetch(`${API_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || 'Login failed');
+    }
+
+    const data = await res.json();
+    setToken(data.token);
+    setUser(data.user);
+    localStorage.setItem('b1_auth', JSON.stringify({ token: data.token, user: data.user }));
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('b1_auth');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, isAuthenticated: !!token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 
 const navItems = [
   { to: '/admin/events', label: 'Events' },
@@ -8,6 +9,8 @@ const navItems = [
 ]
 
 export function AdminLayout() {
+  const { user, logout } = useAuth()
+
   return (
     <div className="admin-layout">
       <aside className="sidebar">
@@ -23,13 +26,19 @@ export function AdminLayout() {
             </NavLink>
           ))}
         </nav>
+        <div className="sidebar-footer">
+          <button className="logout-btn" onClick={logout}>Logout</button>
+        </div>
       </aside>
       <div className="main-content">
         <header className="topbar">
           <span>Admin Console</span>
-          <NavLink to="/" className="back-link">
-            ← Back to Markets
-          </NavLink>
+          <div className="header-right">
+            {user && <span className="user-email">{user.email}</span>}
+            <NavLink to="/" className="back-link">
+              ← Back to Markets
+            </NavLink>
+          </div>
         </header>
         <main>
           <Outlet />

--- a/src/pages/admin/Login.tsx
+++ b/src/pages/admin/Login.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+
+const DEMO_ADMINS = [
+  { email: 'shaoshixiong@gmail.com', name: 'Orion' },
+  { email: 'mark@locatechs.com', name: 'Mark' },
+];
+
+export function AdminLoginPage() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { login } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      await login(email);
+      navigate('/admin/events');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDemoClick = (demoEmail: string) => {
+    setEmail(demoEmail);
+    setError('');
+  };
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <h1>Admin Login</h1>
+        <p className="login-subtitle">Sign in to access the admin console</p>
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Enter your email"
+              required
+            />
+          </div>
+
+          {error && <div className="error-message">{error}</div>}
+
+          <button type="submit" className="login-btn" disabled={loading}>
+            {loading ? 'Signing in...' : 'Sign In'}
+          </button>
+        </form>
+
+        <div className="demo-section">
+          <p>Demo accounts:</p>
+          <div className="demo-buttons">
+            {DEMO_ADMINS.map((admin) => (
+              <button
+                key={admin.email}
+                type="button"
+                className="demo-btn"
+                onClick={() => handleDemoClick(admin.email)}
+              >
+                {admin.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Backend: POST /auth/login with seeded admin users (Orion, Mark)
- Frontend: /admin/login page with demo account buttons
- Auth context with localStorage session persistence
- Route guard for /admin routes
- Logged-in indicator in header
- README updated with demo credentials

## How to Verify
1. Navigate to `/admin/login`
2. Click demo account button (Orion or Mark)
3. Should redirect to `/admin/events` with user email shown in header
4. Logout button available in header and admin sidebar
5. Accessing `/admin` without auth redirects to login

Closes #10