### PR TITLE
feat: settlement admin UI skeleton (LLM vote + objection + confirm) - closes #25

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -160,3 +160,87 @@ nav a { cursor: pointer; }
 
 .form-actions { display: flex; gap: 12px; justify-content: flex-end; margin-top: 24px; }
 .success-message { margin-top: 16px; padding: 12px; background: #22c55e22; color: #4ade80; border: 1px solid #22c55e44; border-radius: 8px; text-align: center; }
+
+/* Settlement page */
+.settlement-stages { display: flex; align-items: center; margin-bottom: 32px; }
+.stage-indicator { display: flex; align-items: center; gap: 10px; padding: 12px 16px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; }
+.stage-indicator.active { border-color: var(--accent); background: rgba(15, 123, 255, 0.1); }
+.stage-indicator.completed { border-color: #22c55e; background: rgba(34, 197, 94, 0.1); }
+.stage-number { width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; background: var(--bg); border-radius: 50%; font-weight: 600; font-size: 14px; }
+.stage-indicator.active .stage-number { background: var(--accent); color: white; }
+.stage-indicator.completed .stage-number { background: #22c55e; color: white; }
+.stage-label { font-size: 14px; font-weight: 500; }
+.stage-line { flex: 1; height: 2px; background: var(--line); margin: 0 16px; }
+
+.settlement-content { display: grid; grid-template-columns: 1fr 400px; gap: 24px; }
+.markets-section h2, .vote-details-panel h2, .objection-section h2, .confirm-section h2 { margin: 0 0 20px; font-size: 18px; }
+.markets-grid { display: flex; flex-direction: column; gap: 12px; }
+.market-card { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 16px; cursor: pointer; transition: border-color 0.2s, transform 0.2s; }
+.market-card:hover { border-color: var(--accent); }
+.market-card.selected { border-color: var(--accent); background: rgba(15, 123, 255, 0.05); }
+.market-card.ready { border-left: 3px solid #22c55e; }
+.market-card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+.market-card h3 { margin: 0 0 6px; font-size: 15px; }
+.market-date { color: var(--muted); font-size: 13px; margin: 0 0 12px; }
+.llm-vote-preview { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.vote-label { color: var(--muted); }
+.vote-outcome { font-weight: 600; color: var(--accent); }
+.vote-confidence { color: var(--muted); }
+
+.status-ready { background: #22c55e22; color: #4ade80; border: 1px solid #22c55e44; }
+.status-pending { background: #f59e0b22; color: #fbbf24; border: 1px solid #f59e0b44; }
+
+.vote-details-panel { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 20px; }
+.vote-details { display: flex; flex-direction: column; gap: 16px; }
+.detail-row { display: flex; flex-direction: column; gap: 6px; }
+.detail-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+.detail-value { font-size: 14px; display: flex; align-items: center; gap: 10px; }
+.detail-value.outcome-highlight { font-weight: 600; color: var(--accent); font-size: 18px; }
+.detail-value.reasoning { color: var(--muted); line-height: 1.5; }
+.confidence-bar { flex: 1; height: 8px; background: var(--bg); border-radius: 4px; overflow: hidden; }
+.confidence-fill { height: 100%; background: linear-gradient(90deg, var(--accent), #22c55e); border-radius: 4px; }
+.panel-actions { display: flex; gap: 12px; margin-top: 24px; }
+.panel-actions .btn-primary { flex: 1; }
+.panel-actions .btn-secondary { flex: 1; }
+
+/* Objection window */
+.objection-section { grid-column: 1 / -1; max-width: 800px; margin: 0 auto; width: 100%; }
+.objection-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+.objection-header h2 { margin: 0; }
+.countdown-placeholder { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; padding: 12px 20px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; }
+.countdown-label { font-size: 12px; color: var(--muted); }
+.countdown-timer { font-size: 24px; font-weight: 700; font-family: monospace; color: #f59e0b; }
+.objection-market-info { display: flex; align-items: center; gap: 16px; padding: 16px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; margin-bottom: 24px; }
+.objection-market-info .market-title { font-weight: 500; flex: 1; }
+.objection-market-info .llm-result { color: var(--muted); font-size: 14px; }
+.objections-list h3 { margin: 0 0 16px; font-size: 16px; }
+.no-objections { padding: 40px; text-align: center; color: var(--muted); background: var(--panel); border: 1px solid var(--line); border-radius: 10px; }
+.objection-cards { display: flex; flex-direction: column; gap: 12px; }
+.objection-card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px; }
+.objection-header-row { display: flex; justify-content: space-between; margin-bottom: 10px; }
+.objection-user { font-weight: 600; font-size: 13px; }
+.objection-time { font-size: 12px; color: var(--muted); }
+.objection-reason { margin: 0; color: var(--muted); font-size: 14px; }
+
+/* Confirm stage */
+.confirm-section { grid-column: 1 / -1; max-width: 800px; margin: 0 auto; width: 100%; }
+.confirm-summary { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-bottom: 24px; }
+.summary-card { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 20px; }
+.summary-card h3 { margin: 0 0 12px; font-size: 14px; color: var(--muted); }
+.summary-card p { margin: 0 0 8px; font-size: 14px; }
+.summary-card .chip { margin-top: 8px; }
+.settlement-outcome { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.outcome-label { color: var(--muted); font-size: 13px; }
+.outcome-value { font-weight: 700; font-size: 20px; color: var(--accent); }
+.confidence-display { font-size: 13px; color: var(--muted); }
+.objection-note { font-size: 12px; color: #f59e0b; font-style: italic; }
+.confirm-warning { display: flex; align-items: center; gap: 12px; padding: 16px; background: rgba(245, 158, 11, 0.1); border: 1px solid #f59e0b44; border-radius: 10px; margin-bottom: 24px; font-size: 14px; }
+.warning-icon { font-size: 20px; }
+.btn-confirm { background: #22c55e; border: 0; color: white; padding: 12px 24px; border-radius: 8px; font-weight: 600; cursor: pointer; }
+.btn-confirm:hover { background: #16a34a; }
+.btn-confirm:disabled { opacity: 0.5; cursor: not-allowed; }
+
+@media (max-width: 900px) {
+  .settlement-content { grid-template-columns: 1fr; }
+  .confirm-summary { grid-template-columns: 1fr; }
+}

--- a/src/pages/admin/Settlement.tsx
+++ b/src/pages/admin/Settlement.tsx
@@ -1,8 +1,305 @@
+import { useState } from 'react'
+
+export type SettlementStage = 'llm-vote' | 'objection' | 'confirm'
+
+export interface MarketToSettle {
+  id: string
+  title: string
+  category: string
+  endDate: string
+  llmVote: {
+    outcome: string
+    confidence: number
+    reasoning: string
+  }
+  objections: Objection[]
+  status: 'pending' | 'ready' | 'settled'
+}
+
+export interface Objection {
+  id: string
+  user: string
+  reason: string
+  timestamp: string
+}
+
+const mockMarkets: MarketToSettle[] = [
+  {
+    id: '1',
+    title: 'Will Bitcoin reach $100k by end of 2025?',
+    category: 'Crypto',
+    endDate: '2025-12-31',
+    llmVote: {
+      outcome: 'Yes',
+      confidence: 78,
+      reasoning: 'Based on current ETF inflows, institutional adoption trends, and historical cycle analysis.',
+    },
+    objections: [
+      { id: 'o1', user: '0x1234...abcd', reason: 'Market conditions have changed significantly', timestamp: '2025-02-10T14:30:00Z' },
+    ],
+    status: 'ready',
+  },
+  {
+    id: '2',
+    title: 'Will AI pass Turing test by June 2025?',
+    category: 'AI',
+    endDate: '2025-06-30',
+    llmVote: {
+      outcome: 'No',
+      confidence: 65,
+      reasoning: 'Current benchmarks suggest insufficient progress for full Turing test passage.',
+    },
+    objections: [],
+    status: 'pending',
+  },
+  {
+    id: '3',
+    title: 'Super Bowl 2026 Winner',
+    category: 'Sports',
+    endDate: '2026-02-08',
+    llmVote: {
+      outcome: 'Chiefs',
+      confidence: 82,
+      reasoning: 'Based on team performance metrics, roster strength, and historical patterns.',
+    },
+    objections: [],
+    status: 'pending',
+  },
+]
+
 export function SettlementPage() {
+  const [markets, setMarkets] = useState<MarketToSettle[]>(mockMarkets)
+  const [selectedMarketId, setSelectedMarketId] = useState<string | null>(null)
+  const [stage, setStage] = useState<SettlementStage>('llm-vote')
+  const [countdown, setCountdown] = useState(3600)
+
+  const selectedMarket = markets.find((m) => m.id === selectedMarketId)
+
+  const pendingMarkets = markets.filter((m) => m.status === 'pending')
+  const readyMarkets = markets.filter((m) => m.status === 'ready')
+
+  const advanceStage = () => {
+    if (stage === 'llm-vote') {
+      setStage('objection')
+      setCountdown(3600)
+    } else if (stage === 'objection') {
+      setStage('confirm')
+    }
+  }
+
+  const resetToLLMVote = () => {
+    setStage('llm-vote')
+    setSelectedMarketId(null)
+  }
+
+  const confirmSettlement = () => {
+    if (selectedMarketId) {
+      setMarkets(markets.map((m) => (m.id === selectedMarketId ? { ...m, status: 'settled' as const } : m)))
+      resetToLLMVote()
+    }
+  }
+
+  const canProceed = selectedMarket && selectedMarket.status === 'ready'
+  const canConfirm = selectedMarket && selectedMarket.status === 'ready' && stage === 'confirm'
+
+  const formatCountdown = (seconds: number) => {
+    const hrs = Math.floor(seconds / 3600)
+    const mins = Math.floor((seconds % 3600) / 60)
+    const secs = seconds % 60
+    return `${hrs.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
+  }
+
   return (
     <div className="admin-page">
-      <h1>Settlement & Risk</h1>
-      <p>Manage market settlements, risk controls, and LLM voting.</p>
+      <div className="page-header">
+        <div>
+          <h1>Settlement & Risk</h1>
+          <p>Manage market settlements, LLM voting, and objection processing.</p>
+        </div>
+      </div>
+
+      <div className="settlement-stages">
+        <div className={`stage-indicator ${stage === 'llm-vote' ? 'active' : 'completed'}`}>
+          <span className="stage-number">1</span>
+          <span className="stage-label">LLM Vote</span>
+        </div>
+        <div className="stage-line" />
+        <div className={`stage-indicator ${stage === 'objection' ? 'active' : stage === 'confirm' ? 'completed' : ''}`}>
+          <span className="stage-number">2</span>
+          <span className="stage-label">Objection Window</span>
+        </div>
+        <div className="stage-line" />
+        <div className={`stage-indicator ${stage === 'confirm' ? 'active' : ''}`}>
+          <span className="stage-number">3</span>
+          <span className="stage-label">Admin Confirm</span>
+        </div>
+      </div>
+
+      {stage === 'llm-vote' && (
+        <div className="settlement-content">
+          <div className="markets-section">
+            <h2>Markets Needing Settlement</h2>
+            <div className="markets-grid">
+              {pendingMarkets.length === 0 && readyMarkets.length === 0 ? (
+                <div className="empty-state">No markets pending settlement.</div>
+              ) : (
+                [...readyMarkets, ...pendingMarkets].map((market) => (
+                  <div
+                    key={market.id}
+                    className={`market-card ${selectedMarketId === market.id ? 'selected' : ''} ${market.status === 'ready' ? 'ready' : ''}`}
+                    onClick={() => setSelectedMarketId(market.id)}
+                  >
+                    <div className="market-card-header">
+                      <span className="chip">{market.category}</span>
+                      <span className={`status-badge status-${market.status === 'ready' ? 'ready' : 'pending'}`}>
+                        {market.status === 'ready' ? 'Ready' : 'Pending'}
+                      </span>
+                    </div>
+                    <h3>{market.title}</h3>
+                    <p className="market-date">End: {market.endDate}</p>
+                    <div className="llm-vote-preview">
+                      <span className="vote-label">LLM Vote:</span>
+                      <span className="vote-outcome">{market.llmVote.outcome}</span>
+                      <span className="vote-confidence">{market.llmVote.confidence}%</span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          {selectedMarket && (
+            <div className="vote-details-panel">
+              <h2>LLM Vote Details</h2>
+              <div className="vote-details">
+                <div className="detail-row">
+                  <span className="detail-label">Market</span>
+                  <span className="detail-value">{selectedMarket.title}</span>
+                </div>
+                <div className="detail-row">
+                  <span className="detail-label">Outcome</span>
+                  <span className="detail-value outcome-highlight">{selectedMarket.llmVote.outcome}</span>
+                </div>
+                <div className="detail-row">
+                  <span className="detail-label">Confidence</span>
+                  <span className="detail-value">
+                    <div className="confidence-bar">
+                      <div className="confidence-fill" style={{ width: `${selectedMarket.llmVote.confidence}%` }} />
+                    </div>
+                    <span>{selectedMarket.llmVote.confidence}%</span>
+                  </span>
+                </div>
+                <div className="detail-row">
+                  <span className="detail-label">Reasoning</span>
+                  <span className="detail-value reasoning">{selectedMarket.llmVote.reasoning}</span>
+                </div>
+              </div>
+              <div className="panel-actions">
+                <button className="btn-primary" disabled={!canProceed} onClick={advanceStage}>
+                  Proceed to Objection Window
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {stage === 'objection' && selectedMarket && (
+        <div className="settlement-content">
+          <div className="objection-section">
+            <div className="objection-header">
+              <h2>Objection Window</h2>
+              <div className="countdown-placeholder">
+                <span className="countdown-label">Time Remaining</span>
+                <span className="countdown-timer">{formatCountdown(countdown)}</span>
+              </div>
+            </div>
+
+            <div className="objection-market-info">
+              <span className="chip">{selectedMarket.category}</span>
+              <span className="market-title">{selectedMarket.title}</span>
+              <span className="llm-result">LLM: {selectedMarket.llmVote.outcome} ({selectedMarket.llmVote.confidence}%)</span>
+            </div>
+
+            <div className="objections-list">
+              <h3>Objections ({selectedMarket.objections.length})</h3>
+              {selectedMarket.objections.length === 0 ? (
+                <div className="no-objections">No objections raised.</div>
+              ) : (
+                <div className="objection-cards">
+                  {selectedMarket.objections.map((obj) => (
+                    <div key={obj.id} className="objection-card">
+                      <div className="objection-header-row">
+                        <span className="objection-user">{obj.user}</span>
+                        <span className="objection-time">{new Date(obj.timestamp).toLocaleString()}</span>
+                      </div>
+                      <p className="objection-reason">{obj.reason}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="panel-actions">
+              <button className="btn-secondary" onClick={resetToLLMVote}>
+                Back
+              </button>
+              <button className="btn-primary" onClick={advanceStage}>
+                Proceed to Confirmation
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {stage === 'confirm' && selectedMarket && (
+        <div className="settlement-content">
+          <div className="confirm-section">
+            <h2>Confirm Settlement</h2>
+
+            <div className="confirm-summary">
+              <div className="summary-card">
+                <h3>Market</h3>
+                <p>{selectedMarket.title}</p>
+                <span className="chip">{selectedMarket.category}</span>
+              </div>
+
+              <div className="summary-card">
+                <h3>Settlement Decision</h3>
+                <div className="settlement-outcome">
+                  <span className="outcome-label">Outcome:</span>
+                  <span className="outcome-value">{selectedMarket.llmVote.outcome}</span>
+                </div>
+                <div className="confidence-display">
+                  Confidence: {selectedMarket.llmVote.confidence}%
+                </div>
+              </div>
+
+              <div className="summary-card">
+                <h3>Objections</h3>
+                <p>{selectedMarket.objections.length} objection(s) received</p>
+                {selectedMarket.objections.length > 0 && (
+                  <p className="objection-note">Objections reviewed and considered.</p>
+                )}
+              </div>
+            </div>
+
+            <div className="confirm-warning">
+              <span className="warning-icon">⚠️</span>
+              <span>This action will permanently settle the market with the selected outcome. This cannot be undone.</span>
+            </div>
+
+            <div className="panel-actions">
+              <button className="btn-secondary" onClick={() => setStage('objection')}>
+                Back
+              </button>
+              <button className="btn-confirm" disabled={!canConfirm} onClick={confirmSettlement}>
+                Confirm Settlement
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Implements settlement admin UI skeleton with 3-stage flow under /admin/settlement
- LLM vote stage: list of markets needing settlement with mock vote results
- Objection window stage: countdown placeholder + objections list
- Admin confirm stage: confirm settlement action button (disabled if not ready)
- Uses local mock state only (no backend required)

## Changes
- src/pages/admin/Settlement.tsx: Full UI skeleton implementation
- src/App.css: CSS styles for settlement page

## Testing
- Build passes successfully

## Notes
- Requesting review from orion-qa